### PR TITLE
Generate & add `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 *.yml text
 *.md text
 *.lock text
+*.sample text
 
 # Declare files that should have CRLF line endings on checkout.
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# This file has been generated using '.gitattributes Generator'.
+# You can generate yours at http://ihopepeace.github.io/gitattributes_generator
+
+* text=auto
+
+# Explicitly declare text files that should be normalized and converted
+# to native line endings on checkout.
+*.js text
+*.json text
+*.yml text
+*.md text
+*.lock text
+
+# Declare files that should have CRLF line endings on checkout.
+
+# Declare files that should have LF line endings on checkout.
+
+# Declare files that are truly binary and shouldn't be modified.
+*.png binary
+*.jpeg binary
+*.gif binary


### PR DESCRIPTION
When having Linux based and Windows based contributors, we get issues with CRLF vs LF. 
This is to solve this issue. 