### PR TITLE
add lint npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "mocha test/compute/ec2.js",
     "coverage": "istanbul --include-all-sources cover _mocha -- -R dot --recursive test/",
-    "lint": "eslint lib; eslint test; exit 0"
+    "lint": "eslint"
   },
   "repository": "https://github.com/cloudlibz/nodecloud",
   "author": "scorelab",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "mocha test/compute/ec2.js",
-    "coverage": "istanbul --include-all-sources cover _mocha -- -R dot --recursive test/"
+    "coverage": "istanbul --include-all-sources cover _mocha -- -R dot --recursive test/",
+    "lint": "eslint lib; eslint test; exit 0"
   },
   "repository": "https://github.com/cloudlibz/nodecloud",
   "author": "scorelab",


### PR DESCRIPTION
## What did you implement:

Closes #23

## How did you implement it:

add new script in package.json

## How can we verify it:

Until now, the only line added is:
"lint": "eslint lib; eslint test; exit 0"
exit 0 tells npm that everything is ok even if there are lint errors.

If you now run `npm run lint`, it will lint /lib and /test.
The person who runs the command should be able to choose the linted directories / files.
This still has to be implemented.

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** NO
***Is it a breaking change?:*** NO
