### PR TITLE
Fix Eslint errors in lib/compute/aws-ec2.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,6 @@
     ],
     "rules": {
         "no-underscore-dangle": [2, { "allowAfterThis": true }],
-        "linebreak-style": ["error", "windows"]
+        "linebreak-style": 0
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,6 @@
         "import"
     ],
     "rules": {
-        "no-underscore-dangle": [2, { "allowAfterThis": true }],
-        "linebreak-style": 0
+        "no-underscore-dangle": [2, { "allowAfterThis": true }]
     }
 }

--- a/lib/compute/aws-ec2.js
+++ b/lib/compute/aws-ec2.js
@@ -35,7 +35,7 @@ class EC2 {
             },
           ],
         };
-        ec2.createTags(ec2Params, (error) => {
+        this._ec2.createTags(ec2Params, (error) => {
           if (error) reject(err);
 
           resolve(instanceId);


### PR DESCRIPTION
## Fix Eslint errors in lib/compute/aws-ec2.js
(GCI 2017)
### The file had 131 errors earlier + 1 created by me to run a pre-commit hook on the file
130 errors  -> Expected linebreaks to be 'CRLF' but found 'LF'
1 error       ->  ec2 is not defined
<img src="https://image.ibb.co/jowNKm/Lint_Errors_Nodecloud.png" height="200">

### This is the result after fixing the Errors
<img src="https://image.ibb.co/ieRiQR/commit_succeeded.png" height="100">