### PR TITLE
Fix Eslinting error

### DIFF
--- a/examples/network/aws-directconnect.js
+++ b/examples/network/aws-directconnect.js
@@ -12,7 +12,7 @@ const params = {
   bandwidth: 'STRING_VALUE',
   connectionName: 'STRING_VALUE',
   location: 'STRING_VALUE',
-  lagId: 'STRING_VALUE'
+  lagId: 'STRING_VALUE',
 };
 
 // create connection


### PR DESCRIPTION
/nodecloud/examples/network/aws-directconnect.js
  15:24  error    Missing trailing comma        comma-dangle

