### PR TITLE
Fix #38 add storage object call in s3 example and remove region const…

### DIFF
--- a/examples/storage/aws-s3.js
+++ b/examples/storage/aws-s3.js
@@ -5,15 +5,12 @@ const options = {
   apiVersion: '2016-11-15',
 };
 
-// get compute object for AWS
-const s3 = ncAWS.s3(options);
+// get storage object for AWS
+const s3 = ncAWS.bucket(options);
 
 // create S3 Bucket
 const params = {
-  Bucket: 'ncbucketcr1',
-  CreateBucketConfiguration: {
-    LocationConstraint: 'us-west-2',
-  },
+  Bucket: 'ncbucketcr1'
 };
 
 console.log('creating bucket');
@@ -26,4 +23,3 @@ s3
   .catch((err) => {
     console.error(`Oops something happened ${err}`);
   });
-


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/cloudlibz/nodecloud/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #38 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added `storage` object instead of `s3` it used first which didn't exist. Also removed the region check since the region was picked from environment config, now the example works.
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run the AWS S3 example,
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

-->

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
