### PR TITLE
fix: undefined error if credentials file not present

### DIFF
--- a/lib/core/aws/provider.js
+++ b/lib/core/aws/provider.js
@@ -17,7 +17,6 @@ class AWS {
    */
   constructor(configPath) {
     this._AWS = awsSDk;
-    
     if (
       !this._AWS.config.credentials ||
       !this._AWS.config.credentials.accessKeyId ||

--- a/lib/core/aws/provider.js
+++ b/lib/core/aws/provider.js
@@ -17,8 +17,9 @@ class AWS {
    */
   constructor(configPath) {
     this._AWS = awsSDk;
-
+    
     if (
+      !this._AWS.config.credentials ||
       !this._AWS.config.credentials.accessKeyId ||
       !this._AWS.config.credentials.secretAccessKey ||
       !process.env.AWS_REGION


### PR DESCRIPTION
## What did you implement:

Closes #58 

## How did you implement it:
Added an extra check in ```lib/core/aws/provider.js``` to check for aws credentials being null or undefined

## How can we verify it:
• Unset the existing aws credentials
• Pass the path to your config.json in ```process.env.ncconf```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
