### PR TITLE
Fix: Correct the url to mock in storage tests

### DIFF
--- a/test/storage/aws-s3.js
+++ b/test/storage/aws-s3.js
@@ -14,7 +14,7 @@ describe('AWS S3', () => {
   before(() => {});
 
   it('should create S3 bucket', (done) => {
-    nock('https://ncbucketcr.s3-us-west-2.amazonaws.com:443', {
+    nock('https://ncbucketcr.s3.us-west-2.amazonaws.com:443', {
       encodedQueryParams: true,
     })
       .put(
@@ -50,7 +50,7 @@ describe('AWS S3', () => {
   });
 
   it('should not delete S3 bucket', (done) => {
-    nock('https://ncbucketcr.s3-us-west-2.amazonaws.com:443', {
+    nock('https://ncbucketcr.s3.us-west-2.amazonaws.com:443', {
       encodedQueryParams: true,
     })
       .delete('/')
@@ -90,7 +90,7 @@ describe('AWS S3', () => {
   });
 
   it('should create multipart upload', (done) => {
-    nock('https://ncbucketcr.s3-us-west-2.amazonaws.com:443', {
+    nock('https://ncbucketcr.s3.us-west-2.amazonaws.com:443', {
       encodedQueryParams: true,
     })
       .post('/largeobject')
@@ -126,7 +126,7 @@ describe('AWS S3', () => {
   });
 
   it('should list all buckets', (done) => {
-    nock('https://s3-us-west-2.amazonaws.com:443', { encodedQueryParams: true })
+    nock('https://s3.us-west-2.amazonaws.com:443', { encodedQueryParams: true })
       .get('/')
       .reply(
         200,
@@ -146,7 +146,7 @@ describe('AWS S3', () => {
           'AmazonS3'
         ]
       );
-
+      
     s3.list({}).then((res) => {
       assert.typeOf(res.Buckets, 'array');
       done();
@@ -154,7 +154,7 @@ describe('AWS S3', () => {
   });
 
   it('should upload an arbitary sized buffer, blob, or stream', (done) => {
-    nock('https://ncbucketcr.s3-us-west-2.amazonaws.com:443', {
+    nock('https://ncbucketcr.s3.us-west-2.amazonaws.com:443', {
       encodedQueryParams: true,
     })
       .put('/key', 'ncunittest')
@@ -178,7 +178,7 @@ describe('AWS S3', () => {
     s3.upload(params).then((res) => {
       assert.equal(
         res.Location,
-        `https://${params.Bucket}.s3-us-west-2.amazonaws.com/key`
+        `https://${params.Bucket}.s3.us-west-2.amazonaws.com/key`
       );
       assert.equal(res.Bucket, params.Bucket);
       done();


### PR DESCRIPTION
## What did you implement:
Fixed the url to mock in storage tests.

Closes #54 and #60 

## How can we verify it:
Run AWS storage tests. Now they are all coming to be a success. 
```
yarn run v1.5.1
$ mocha test/storage/aws-s3.js


  AWS S3
    ✓ should create S3 bucket (64ms)
    ✓ should not delete S3 bucket
    ✓ should create multipart upload
    ✓ should list all buckets
    ✓ should upload an arbitary sized buffer, blob, or stream


  5 passing (127ms)

✨  Done in 6.40s.
```

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Make sure code coverage hasn't dropped
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

***Is this ready for review?:*** YES
***Is it a breaking change?:*** NO
